### PR TITLE
Set changelist.format for automated releases

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=-%d.v%s


### PR DESCRIPTION
## Set changelist.format for automated releases

The ["Automated release" documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) includes a section that describes the automated release configuration used in this repository.  The section is "Manually controlled prefix (optional)" and it includes instructions that the .mvn/maven.config file must include the line:

```
-Dchangelist.format=%d.v%s
```

The .mvn/maven.config in the repository does not include that line, so Maven is using the default value of the changelist.format.

A little earlier in that page, it includes the instructions so that a developer can check the version number pattern that they have selected.  The commands to check that are:

```
mvn validate
mvn validate -Dset.changelist -Dignore.dirt
```

When I run `mvn validate` on this repository before this change, one of the output lines is:

```
[INFO] Building Leapwork 4.0.12-SNAPSHOT
```

When I run `mvn validate -Dset.changelist -Dignore.dirt` on this repository before this change, one of the output lines is:

```
[INFO] Building Leapwork 4.0.12-rc93.784bbceeef27
```

That output is because the `changelist.format` is not set in the .mvn/maven.config file.

After I added the `changelist.format`, the output is now:

```
[INFO] Building Leapwork 4.0.12-93.v784bbceeef27
```

### Testing done

Confirmed that `mvn validate` output has expected format with changes and that it has the undesired format before this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
