### PR TITLE
Rely on plugin BOM to provide plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,17 +64,14 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>jquery3-api</artifactId>
-			<version>3.7.1-2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>commons-lang3-api</artifactId>
-			<version>3.13.0-62.v7d18e55f51e2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>commons-text-api</artifactId>
-			<version>1.11.0-95.v22a_d30ee5d36</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Rely on plugin BOM to provide plugin versions

One of the benefits of the plugin bill of materials is that it allows the plugin maintainer to delegate the tracking of plugin versions to the plugin BOM, instead of tracking those versions in the pom.xml file.

Remove the version numbers for plugins that are tracked by the plugin bill of materials.

### Testing done

Confirmed that `mvn clean -DskipTests verify` passes.  Rely on ci.jenkins.io for more verification.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
